### PR TITLE
Enable infinite scroll.

### DIFF
--- a/app/src/main/java/com/codepath/apps/simpletwitterclient/adapters/TweetsArrayAdapter.java
+++ b/app/src/main/java/com/codepath/apps/simpletwitterclient/adapters/TweetsArrayAdapter.java
@@ -63,8 +63,6 @@ public class TweetsArrayAdapter extends ArrayAdapter<Tweet>{
         viewHolder.body.setText(tweet.getBody());
         viewHolder.profileImage.setImageResource(android.R.color.transparent); //clear out image for recycled view
 
-        //Log.i(TAG, tweet.getUser().getScreenName() + "-->" + tweet.getBody());
-
         Picasso.with(getContext()).load(tweet.getUser().getProfileImageUrl()).into(viewHolder.profileImage);
 
         return convertView;

--- a/app/src/main/java/com/codepath/apps/simpletwitterclient/lib/Time.java
+++ b/app/src/main/java/com/codepath/apps/simpletwitterclient/lib/Time.java
@@ -2,13 +2,13 @@ package com.codepath.apps.simpletwitterclient.lib;
 
 
 import android.text.format.DateUtils;
-import android.util.Log;
 
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 
 public class Time {
 
+    private static final String TAG = "Time";
 
     /**
      * Copied directly from:
@@ -34,11 +34,7 @@ public class Time {
 
     public static String getTimeAgo(String rawJsonDate) {
         String longFormat = Time.getRelativeTimeAgo(rawJsonDate);
-
-        Log.i("debug", "       "+longFormat);
-
         String[] parts = longFormat.split(" ");
-
         return parts[0] + parts[1].substring(0,1);
     }
 

--- a/app/src/main/java/com/codepath/apps/simpletwitterclient/listeners/EndlessScrollListener.java
+++ b/app/src/main/java/com/codepath/apps/simpletwitterclient/listeners/EndlessScrollListener.java
@@ -1,0 +1,81 @@
+package com.codepath.apps.simpletwitterclient.listeners;
+
+
+import android.widget.AbsListView;
+
+/**
+ * Page state is not needed here, since tweets aren't retrieved by pages. Instead tweets are retrieved
+ * based upon their ids, which are tracked outside of this class. This class is just used to inform
+ * the caller that more data needs to be fetched.
+ */
+public abstract class EndlessScrollListener implements AbsListView.OnScrollListener{
+
+    private final static String TAG = "EndlessScrollListener";
+
+    // Min items to have below cur position before loading more
+    private int visibleThreshold = 10;
+    // Total number of items in the dataset after the last load
+    private int previousTotalItemCount = 0;
+    // true if we are still waiting for the last set of data to load
+    private boolean loading = true;
+
+    public EndlessScrollListener() {
+
+    }
+
+    /**
+     * From: http://developer.android.com/reference/android/widget/AbsListView.OnScrollListener.html#onScroll(android.widget.AbsListView, int, int, int)
+     * @param view - View The view who's scroll state is being reported
+     * @param firstVisibleItem int the index of the first visible cell (ignore if visibleItemCount == 0)
+     * @param visibleItemCount int the number of visible cells
+     * @param totalItemCount int the number of items in the list adapter
+     */
+    @Override
+    public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
+
+        /**
+         * If the total item count is 0 and the previous isn't, assume the list is invalid and
+         * reset back to initial state
+         *
+         * Note: This seems like a weird state. Isn't it always an error when totalItemCount is less
+         * than the previous total item count?
+         */
+        if (totalItemCount < previousTotalItemCount) {
+            this.previousTotalItemCount = totalItemCount;
+
+            if (totalItemCount == 0) {
+                this.loading = true;
+            }
+        }
+
+        /**
+         * If still loading, check if the dataset count has changed. If so, then it has finished
+         * loading and the current page and total item count can be updated.
+         */
+        if (loading && (totalItemCount > previousTotalItemCount)) {
+            loading = false;
+            previousTotalItemCount = totalItemCount;
+        }
+
+        /**
+         * If not currently loading, check if we have breached the visibleThreshold to reload more
+         * data. If so, execute onLoadMore and fetch the data
+         *
+         * reordered to make more sense:
+         */
+        if (!loading && (firstVisibleItem + visibleThreshold + visibleItemCount >= totalItemCount)) {
+            onLoadMore();
+            loading = true;
+        }
+    }
+
+    /**
+     * Defines the process for actually loading more data based on page
+     */
+    public abstract void onLoadMore();
+
+    @Override
+    public void onScrollStateChanged(AbsListView view, int scrollState) {
+        // No need to do anything
+    }
+}

--- a/app/src/main/java/com/codepath/apps/simpletwitterclient/networking/TwitterClient.java
+++ b/app/src/main/java/com/codepath/apps/simpletwitterclient/networking/TwitterClient.java
@@ -28,6 +28,8 @@ public class TwitterClient extends OAuthBaseClient {
 	public static final String REST_CONSUMER_SECRET = "GlqHMgulVGVdOR4sRf3YBlagNRTXsMTKIf9bgdL3sf1xrhm4cU"; // Change this
 	public static final String REST_CALLBACK_URL = "oauth://cpsimpletwitterclient"; // Change this (here and in manifest)
 
+    private static final String TAG = "TwitterClient";
+
 	public TwitterClient(Context context) {
 		super(context, REST_API_CLASS, REST_URL, REST_CONSUMER_KEY, REST_CONSUMER_SECRET, REST_CALLBACK_URL);
 	}
@@ -41,13 +43,14 @@ url: GET statuses/home_timeline.json
 	count = 25
 	since_id=1
  */
-    public void getHomeTimeline(AsyncHttpResponseHandler handler) {
+    public void getHomeTimeline(long maxId, AsyncHttpResponseHandler handler) {
         String apiUrl = getApiUrl("statuses/home_timeline.json");
 
         //Specify Params
         RequestParams params = new RequestParams();
         params.put("count", 25);
         params.put("since_id", 1);
+        params.put("max_id", maxId);
 
         // Execute
         getClient().get(apiUrl, params, handler);


### PR DESCRIPTION
Currently, the Timeline keeps track of the max tweet id currently in memory.
To fetch more, just fetch tweets with ids greater than the current max.
