### PR TITLE
Fix pull to refresh indicator. It should disappear when loading

### DIFF
--- a/app/src/main/java/com/codepath/apps/simpletwitterclient/activities/TimelineActivity.java
+++ b/app/src/main/java/com/codepath/apps/simpletwitterclient/activities/TimelineActivity.java
@@ -252,6 +252,7 @@ public class TimelineActivity extends ActionBarActivity {
             Toaster.create(TimelineActivity.this, "Sorry, the network appears to be down. Using cached data");
             Toaster.create(TimelineActivity.this, "Pull to refresh to try again");
             loadTweetsFromCache();
+            swipeContainer.setRefreshing(false);
         }
     }
 


### PR DESCRIPTION
cached tweets.
